### PR TITLE
Handle multiple link headers

### DIFF
--- a/autodiscovery/namespace.php
+++ b/autodiscovery/namespace.php
@@ -46,7 +46,14 @@ function discover_api_root( $uri, $legacy = false ) {
 	}
 
 	$links = wp_remote_retrieve_header( $response, 'link' );
-	$links = explode( ',', $links );
+
+	if ( is_array( $links ) ) {
+		$links = array_reduce( $links, function( $links, $link ) {
+			return array_merge( $links, explode( ',', $link ) );
+		}, array() );
+	} else {
+		$links = explode( ',', $links );
+	}
 
 	// Find the correct link by relation
 	foreach ( $links as $link ) {

--- a/autodiscovery/namespace.php
+++ b/autodiscovery/namespace.php
@@ -48,7 +48,7 @@ function discover_api_root( $uri, $legacy = false ) {
 	$links = wp_remote_retrieve_header( $response, 'link' );
 
 	if ( is_array( $links ) ) {
-		$links = array_reduce( $links, function( $links, $link ) {
+		$links = array_reduce( $links, function ( $links, $link ) {
 			return array_merge( $links, explode( ',', $link ) );
 		}, array() );
 	} else {


### PR DESCRIPTION
Currently if the response headers for a site is something link:

```
Link: <http://www.xn--tm-cka.com/wp-json/>; rel="https://api.w.org/"
Link: <http://www.xn--tm-cka.com/>; rel=shortlink
```

Then we get a fatal error, let's fix that!
